### PR TITLE
Last release not working with jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@ Yes.
 Add dependency to `build.gradle`:
 
 ```groovy
-allprojects {
-    repositories {
-        maven { url "https://jitpack.io" }
-    }
-}
-
 dependencies {
     // refer to badge for latest version
     compile 'com.github.ankurcha:gcloud-logging-slf4j-logback:LATEST'


### PR DESCRIPTION
I see that new release push to maven repo, so dont' need to specify jitpack. and it is actually fail on jitpack: 
https://jitpack.io/com/github/ankurcha/gcloud-logging-slf4j-logback/1.1.3/build.log