### PR TITLE
Add custom attributes to log messages

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.github.ankurcha
 name=gcloud-logging-slf4j-logback
-version=1.1.11
+version=1.2.0

--- a/src/main/java/com/google/cloud/logging/CustomAttributes.java
+++ b/src/main/java/com/google/cloud/logging/CustomAttributes.java
@@ -1,0 +1,17 @@
+package com.google.cloud.logging;
+
+import java.util.Map;
+
+public class CustomAttributes {
+
+    private final Map<String, Object> attributes;
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public CustomAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+}

--- a/src/main/java/com/google/cloud/logging/GoogleCloudLoggingV2Layout.java
+++ b/src/main/java/com/google/cloud/logging/GoogleCloudLoggingV2Layout.java
@@ -121,6 +121,13 @@ public class GoogleCloudLoggingV2Layout extends JsonLayoutBase<ILoggingEvent> {
                     if (arg instanceof HttpRequestContext) {
                         reqCtx = (HttpRequestContext) arg;
                     }
+
+                    if (arg instanceof CustomAttributes) {
+                        Map<String, Object> attributes = ((CustomAttributes) arg).getAttributes();
+                        if (attributes != null) {
+                            builder.putAll(attributes);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
From looking at the current implementation it looks to me like there is no way of attaching arbitrary information to a log message aside from using the MDC, which groups all the information under `details` and also looks like it only works properly if a single request is not multiplexed across multiple threads.

This pull-request provides a simple implementation for attaching custom information to a log entry.